### PR TITLE
Add functionality to delete card with x button and not entire card

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,8 +87,10 @@ function getId(e) {
   var index = ideasArray.findIndex(function(idea) {
      return idea.id == findId;
 })
+if (e.target.classList[0] === "article__delete") {
 e.target.closest('article').remove();
 ideasArray[index].deleteFromStorage(index);
+ }
 }
 
 // function deleteCard(e) {


### PR DESCRIPTION
Co-authored-by: Allison Wagner <allisonjw01@gmail.com>

We now can delete cards by just clicking the x image and only the x image. The cards will not delete now when clicking elsewhere on the card as before.